### PR TITLE
Add simple add page

### DIFF
--- a/src/nav-items.jsx
+++ b/src/nav-items.jsx
@@ -1,5 +1,6 @@
-import { HomeIcon, Image as ImageIcon } from "lucide-react";
+import { HomeIcon, Image as ImageIcon, PlusIcon } from "lucide-react";
 import Index from "./pages/Index.jsx";
+import Add from "./pages/Add.jsx";
 
 /**
 * Central place for defining the navigation items. Used for navigation components and routing.
@@ -10,5 +11,11 @@ export const navItems = [
     to: "/",
     icon: <HomeIcon className="h-4 w-4" />,
     page: <Index />,
+  },
+  {
+    title: "新增",
+    to: "/add",
+    icon: <PlusIcon className="h-4 w-4" />,
+    page: <Add />,
   },
 ];

--- a/src/pages/Add.css
+++ b/src/pages/Add.css
@@ -1,0 +1,19 @@
+:root {
+  --primary: 79, 70, 229;
+  --secondary: 139, 92, 246;
+  --accent: 236, 72, 153;
+  --surface: 241, 245, 249;
+  --on-surface: 15, 23, 42;
+  --card: 255, 255, 255;
+  --border: 229, 231, 235;
+}
+
+.dark {
+  --primary: 129, 140, 248;
+  --secondary: 167, 139, 250;
+  --accent: 244, 114, 182;
+  --surface: 15, 23, 42;
+  --on-surface: 241, 245, 249;
+  --card: 30, 41, 59;
+  --border: 55, 65, 81;
+}

--- a/src/pages/Add.jsx
+++ b/src/pages/Add.jsx
@@ -1,0 +1,139 @@
+import { useState, useEffect } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+  CardFooter,
+} from '@/components/ui/card';
+import '../pages/Add.css';
+
+const defaultForm = {
+  title: '',
+  description: '',
+  url: '',
+  tags: '',
+  content: '',
+};
+
+const Add = () => {
+  const [cards, setCards] = useState([]);
+  const [showForm, setShowForm] = useState(false);
+  const [form, setForm] = useState(defaultForm);
+
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem('customCards');
+      if (stored) {
+        setCards(JSON.parse(stored));
+      }
+    } catch {}
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem('customCards', JSON.stringify(cards));
+  }, [cards]);
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setForm({ ...form, [name]: value });
+  };
+
+  const handleAdd = () => {
+    const newCard = {
+      id: Date.now(),
+      title: form.title || '无标题',
+      description: form.description,
+      url: form.url,
+      content: form.content,
+      tags: form.tags.trim().split(/\s+/).filter(Boolean),
+    };
+    setCards([...cards, newCard]);
+    setForm(defaultForm);
+    setShowForm(false);
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <Button onClick={() => setShowForm(!showForm)}>新增卡片</Button>
+      {showForm && (
+        <div className="space-y-2 max-w-xl">
+          <Input
+            name="title"
+            placeholder="标题"
+            value={form.title}
+            onChange={handleChange}
+          />
+          <Input
+            name="description"
+            placeholder="描述"
+            value={form.description}
+            onChange={handleChange}
+          />
+          <Input
+            name="url"
+            placeholder="链接 可选"
+            value={form.url}
+            onChange={handleChange}
+          />
+          <Textarea
+            name="content"
+            placeholder="内容 可选"
+            value={form.content}
+            onChange={handleChange}
+          />
+          <Input
+            name="tags"
+            placeholder="标签 用空格分隔"
+            value={form.tags}
+            onChange={handleChange}
+          />
+          <div className="flex gap-2">
+            <Button onClick={handleAdd}>保存</Button>
+            <Button variant="secondary" onClick={() => setShowForm(false)}>
+              取消
+            </Button>
+          </div>
+        </div>
+      )}
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        {cards.map((card) => (
+          <Card key={card.id} className="flex flex-col">
+            <CardHeader>
+              <CardTitle>{card.title}</CardTitle>
+              {card.description && (
+                <CardDescription>{card.description}</CardDescription>
+              )}
+            </CardHeader>
+            <CardContent className="space-y-2">
+              {card.content && (
+                <pre className="whitespace-pre-wrap text-sm">{card.content}</pre>
+              )}
+              {card.url && (
+                <a
+                  href={card.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-sm text-primary underline"
+                >
+                  查看链接
+                </a>
+              )}
+            </CardContent>
+            <CardFooter className="flex gap-1 flex-wrap">
+              {card.tags.map((tag) => (
+                <span key={tag} className="text-xs text-gray-500">#{tag}</span>
+              ))}
+            </CardFooter>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default Add;


### PR DESCRIPTION
## Summary
- implement Add page to allow creating cards stored in localStorage
- expose the new page via navigation
- include color CSS variables

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_b_6864e30c2bc4832e85423be7ebfc6cb8